### PR TITLE
[fix/15-getRecruitmentList] 띱 목록 조회 시, active 상태의 participant만 조회하도록 수정

### DIFF
--- a/src/main/java/com/hatcher/haemo/recruitment/application/RecruitmentService.java
+++ b/src/main/java/com/hatcher/haemo/recruitment/application/RecruitmentService.java
@@ -65,22 +65,25 @@ public class RecruitmentService {
         try {
             Long userIdx = authService.getUserIdx();
             List<RecruitmentDto> recruitmentList = new ArrayList<>();
-            if (isParticipant) { // 참여중인 띱 목록 조회 //TODO: Participant active 상태인것만
-                if (userIdx != null) {
+            if (isParticipant) { // 참여중인 띱 목록 조회
+                if (userIdx != null) { // 회원
                     User user = userRepository.findById(userService.getUserIdxWithValidation()).orElseThrow(() -> new BaseException(INVALID_USER_IDX));
                     // 리더로 있는 recruitment 목록 조회
                     Stream<Recruitment> leaderRecruitmentStream = user.getRecruitments().stream();
 
                     // 참여자로 있는 recruitment 목록 조회
                     Stream<Recruitment> participantRecruitmentStream = user.getParticipants().stream()
+                            .filter(participant -> participant.getStatus().equals(ACTIVE))
                             .map(Participant::getRecruitment);
 
                     List<RecruitmentDto> sortedRecruitmentList = Stream.concat(leaderRecruitmentStream, participantRecruitmentStream)
                             .sorted(Comparator.comparing(Recruitment::getCreatedDate).reversed())
                             .map(recruitment -> new RecruitmentDto(recruitment.getRecruitmentIdx(), recruitment.getType().getDescription(), recruitment.getName(),
-                                    recruitment.getLeader().getNickname(), recruitment.getParticipants().size(), recruitment.getParticipantLimit(), recruitment.getDescription(),
+                                    recruitment.getLeader().getNickname(), recruitment.getParticipants().size()+1, recruitment.getParticipantLimit(), recruitment.getDescription(),
                                     recruitment.getLeader().equals(user), recruitment.getStatus().equals(DONE))).toList();
                     recruitmentList.addAll(sortedRecruitmentList);
+                } else { // 비회원
+                    recruitmentList = null;
                 }
             } else {
                 if (type == null) { // 모집중인 띱 목록 조회
@@ -113,7 +116,7 @@ public class RecruitmentService {
                         isLeader = recruitment.getLeader().equals(finalUser);
                     }
                     return new RecruitmentDto(recruitment.getRecruitmentIdx(), recruitment.getType().getDescription(), recruitment.getName(),
-                            recruitment.getLeader().getNickname(), recruitment.getParticipants().size(), recruitment.getParticipantLimit(), recruitment.getDescription(),
+                            recruitment.getLeader().getNickname(), recruitment.getParticipants().size()+1, recruitment.getParticipantLimit(), recruitment.getDescription(),
                             isLeader, false);
                 }).toList();
         return recruitmentList;
@@ -169,7 +172,7 @@ public class RecruitmentService {
             if (recruitmentEditRequest.participantLimit() != null) {
                 if (recruitmentEditRequest.participantLimit() < recruitment.getParticipants().size()+1) //TODO: participantNumber 구할 때 participant 상태가 active인 것만 세기
                     throw new BaseException(LARGER_THAN_CURRENT_PARTICIPANT);
-                else if (recruitmentEditRequest.participantLimit() == recruitment.getParticipants().size()) { //TODO: participantNumber 구할 때 participant 상태가 active인 것만 세기
+                else if (recruitmentEditRequest.participantLimit() == recruitment.getParticipants().size()+1) { //TODO: participantNumber 구할 때 participant 상태가 active인 것만 세기
                     recruitment.setStatus(DONE);
                 } else recruitment.modifyParticipantLimit(recruitmentEditRequest.participantLimit());
             }

--- a/src/main/java/com/hatcher/haemo/recruitment/application/RecruitmentService.java
+++ b/src/main/java/com/hatcher/haemo/recruitment/application/RecruitmentService.java
@@ -97,6 +97,7 @@ public class RecruitmentService {
         }
     }
 
+    // recruiting 상태 모집글 목록 조회
     private List<RecruitmentDto> getRecruitmentList(List<Recruitment> recruitmentRepositoryList, Long userIdx) throws BaseException {
         List<RecruitmentDto> recruitmentList;
         User user = null;
@@ -279,6 +280,19 @@ public class RecruitmentService {
             participant.setStatus(INACTIVE);
             participantRepository.save(participant);
             return new BaseResponse<>(SUCCESS);
+        } catch (BaseException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new BaseException(INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    // [홈] 모집중인 띱 목록 조회(3개)
+    public BaseResponse<RecruitmentListResponse> getRecruitingList() throws BaseException {
+        try {
+            Long userIdx = authService.getUserIdx();
+            List<RecruitmentDto> recruitmentList = getRecruitmentList(recruitmentRepository.findTop3ByStatusOrderByCreatedDateDesc(RECRUITING), userIdx);
+            return new BaseResponse<>(new RecruitmentListResponse(recruitmentList));
         } catch (BaseException e) {
             throw e;
         } catch (Exception e) {

--- a/src/main/java/com/hatcher/haemo/recruitment/presentation/RecruitmentController.java
+++ b/src/main/java/com/hatcher/haemo/recruitment/presentation/RecruitmentController.java
@@ -100,4 +100,14 @@ public class RecruitmentController {
             return new BaseResponse<>(e.getStatus());
         }
     }
+
+    // 모집중인 띱 목록 조회(3개)
+    @GetMapping("/recruiting")
+    public BaseResponse<RecruitmentListResponse> getRecruitingList() {
+        try {
+            return recruitmentService.getRecruitingList();
+        } catch (BaseException e) {
+            return new BaseResponse<>(e.getStatus());
+        }
+    }
 }

--- a/src/main/java/com/hatcher/haemo/recruitment/repository/RecruitmentRepository.java
+++ b/src/main/java/com/hatcher/haemo/recruitment/repository/RecruitmentRepository.java
@@ -10,4 +10,5 @@ public interface RecruitmentRepository extends JpaRepository<Recruitment, Long> 
 
     List<Recruitment> findByStatusOrderByCreatedDateDesc(String status);
     List<Recruitment> findByTypeAndStatusEqualsOrderByCreatedDateDesc(RecruitType type, String status);
+    List<Recruitment> findTop3ByStatusOrderByCreatedDateDesc(String status);
 }

--- a/src/main/java/com/hatcher/haemo/user/domain/User.java
+++ b/src/main/java/com/hatcher/haemo/user/domain/User.java
@@ -11,7 +11,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.DynamicInsert;
-import org.hibernate.annotations.Where;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -37,12 +36,10 @@ public class User extends BaseEntity {
     @Column(nullable = false)
     private String nickname;
 
-    @OneToMany(mappedBy = "leader")
-    @Where(clause = "status = 'ACTIVE'")
+    @OneToMany(mappedBy = "leader", fetch = FetchType.EAGER)
     private List<Recruitment> recruitments = new ArrayList<>(); // 해당 user가 leader로 있는 recruitment list
 
     @OneToMany(mappedBy = "writer")
-    @Where(clause = "status = 'ACTIVE'")
     private List<Comment> comments = new ArrayList<>();
 
     @OneToMany(mappedBy = "participant")


### PR DESCRIPTION
## 📌 Issue Number
#15

## 🔨 Changes 
- 참여 목록 조회 시 비회원이면 null, 참여하는 띱이 없는 회원이면 빈 리스트 반환
- Participant 조회 시 active 상태만 조회

## 💬 Discussion
